### PR TITLE
Include authored PRs in pings

### DIFF
--- a/src/discord/tasks/watch_github.rs
+++ b/src/discord/tasks/watch_github.rs
@@ -92,13 +92,9 @@ async fn report_alerts(
     ignore_time_for_guild_id: Option<model::DiscordGuildId>,
     filter_to_discord_user: Option<model::DiscordUserId>,
 ) -> Result<(), DiscordError> {
-    struct UserAlertInfo {
-        discord_user_id: model::DiscordUserId,
-        github_names: Vec<model::GithubUserName>,
-    }
     struct GuildAlerts {
         discord_channel_id: model::DiscordChannelId,
-        users: Vec<UserAlertInfo>,
+        discord_user_ids: Vec<model::DiscordUserId>,
         prs: Arc<Vec<github::Pr>>,
         issues: Arc<Vec<github::LeadsIssue>>,
     }
@@ -132,26 +128,20 @@ async fn report_alerts(
             let issues_state =
                 github::get_leads_issues(&guild_config.repo_owner, &guild_config.repo_name).await?;
 
-            let mut users_to_alert: Vec<UserAlertInfo> = Vec::new();
+            let mut discord_user_ids_to_alert: Vec<model::DiscordUserId> = Vec::new();
             let mut discord_user_ids_to_weekly_alert: Vec<model::DiscordUserId> = Vec::new();
-            for (discord_user_id, user_config) in &guild_config.users {
+            for (discord_user_id, _) in &guild_config.users {
                 let user_alerts = model::discord_user_report_times(guild_config, discord_user_id);
 
                 if guild_ignores_time(guild_id) {
-                    users_to_alert.push(UserAlertInfo {
-                        discord_user_id: discord_user_id.clone(),
-                        github_names: user_config.github_names.clone(),
-                    });
+                    discord_user_ids_to_alert.push(discord_user_id.clone());
                     discord_user_ids_to_weekly_alert.push(discord_user_id.clone());
                 } else {
                     // Look for any alert times that we have passed since the last report attempt.
                     let should_report =
                         |report_time| last_report_timestamp < report_time && now >= report_time;
                     if user_alerts.iter().any(should_report) {
-                        users_to_alert.push(UserAlertInfo {
-                            discord_user_id: discord_user_id.clone(),
-                            github_names: user_config.github_names.clone(),
-                        });
+                        discord_user_ids_to_alert.push(discord_user_id.clone());
 
                         if model::discord_user_weekly_report_needed(guild_config, discord_user_id) {
                             discord_user_ids_to_weekly_alert.push(discord_user_id.clone());
@@ -161,7 +151,7 @@ async fn report_alerts(
             }
 
             if let Some(filter_user) = &filter_to_discord_user {
-                users_to_alert.retain(|u| u.discord_user_id == *filter_user);
+                discord_user_ids_to_alert.retain_mut(|user| *user == *filter_user);
                 discord_user_ids_to_weekly_alert.retain_mut(|user| *user == *filter_user);
             }
 
@@ -173,7 +163,7 @@ async fn report_alerts(
 
             alerts.push(GuildAlerts {
                 discord_channel_id: guild_config.report_channel_id.clone(),
-                users: users_to_alert,
+                discord_user_ids: discord_user_ids_to_alert,
                 prs,
                 issues: issues.clone(),
             });
@@ -215,14 +205,13 @@ async fn report_alerts(
     discord::util::save_config(&data).await?;
 
     for alert in alerts {
-        for user_info in alert.users {
+        for discord_user_id in alert.discord_user_ids {
             report_alerts_for_user(
                 http.clone(),
                 alert.prs.clone(),
                 alert.issues.clone(),
                 alert.discord_channel_id.clone(),
-                user_info.discord_user_id,
-                &user_info.github_names,
+                discord_user_id,
             )
             .await?;
         }
@@ -326,7 +315,6 @@ async fn report_alerts_for_user(
     issues: Arc<Vec<github::LeadsIssue>>,
     discord_channel_id: model::DiscordChannelId,
     discord_user_id: model::DiscordUserId,
-    github_names: &[model::GithubUserName],
 ) -> Result<(), DiscordError> {
     const PR_HEADER: &str = ":notepad_spiral: PRs for review ";
     const BLOCKING_ISSUES_HEADER: &str = ":fire_engine: Open leads issues (blocking) ";
@@ -351,7 +339,7 @@ async fn report_alerts_for_user(
     )
     .await?;
 
-    let user_prs: Vec<_> = prs
+    let review_prs: Vec<_> = prs
         .iter()
         .filter(|pr| {
             pr.reviewers
@@ -359,18 +347,17 @@ async fn report_alerts_for_user(
                 .any(|r| r.discord_users.contains(&discord_user_id))
         })
         .collect();
-    let user_issues: Vec<_> = issues
+    let review_issues: Vec<_> = issues
         .iter()
         .filter(|issue: &_| {
             issue.urgency == github::Urgency::Blocked && issue.leads.contains(&discord_user_id)
         })
         .collect();
-    let my_prs: Vec<_> = prs
+    let author_prs: Vec<_> = prs
         .iter()
         .filter(|pr| {
-            let is_author = pr.github_pr.user.as_ref().map_or(false, |u| {
-                let github_name: model::GithubUserName = u.as_ref().into();
-                github_names.contains(&github_name)
+            let is_author = pr.author.as_ref().map_or(false, |a| {
+                a.discord_users.contains(&discord_user_id)
             });
 
             let no_reviewers = pr.reviewers.is_empty();
@@ -384,7 +371,7 @@ async fn report_alerts_for_user(
     generate_alert_messages(
         http.clone(),
         pr_header,
-        user_prs,
+        review_prs,
         format_pr,
         discord_channel_id.clone(),
     )
@@ -392,7 +379,7 @@ async fn report_alerts_for_user(
     generate_alert_messages(
         http.clone(),
         issue_header,
-        user_issues,
+        review_issues,
         format_issue,
         discord_channel_id.clone(),
     )
@@ -400,7 +387,7 @@ async fn report_alerts_for_user(
     generate_alert_messages(
         http,
         my_prs_header,
-        my_prs,
+        author_prs,
         format_pr,
         discord_channel_id,
     )

--- a/src/discord/tasks/watch_github.rs
+++ b/src/discord/tasks/watch_github.rs
@@ -92,9 +92,13 @@ async fn report_alerts(
     ignore_time_for_guild_id: Option<model::DiscordGuildId>,
     filter_to_discord_user: Option<model::DiscordUserId>,
 ) -> Result<(), DiscordError> {
+    struct UserAlertInfo {
+        discord_user_id: model::DiscordUserId,
+        github_names: Vec<model::GithubUserName>,
+    }
     struct GuildAlerts {
         discord_channel_id: model::DiscordChannelId,
-        discord_user_ids: Vec<model::DiscordUserId>,
+        users: Vec<UserAlertInfo>,
         prs: Arc<Vec<github::Pr>>,
         issues: Arc<Vec<github::LeadsIssue>>,
     }
@@ -128,20 +132,26 @@ async fn report_alerts(
             let issues_state =
                 github::get_leads_issues(&guild_config.repo_owner, &guild_config.repo_name).await?;
 
-            let mut discord_user_ids_to_alert: Vec<model::DiscordUserId> = Vec::new();
+            let mut users_to_alert: Vec<UserAlertInfo> = Vec::new();
             let mut discord_user_ids_to_weekly_alert: Vec<model::DiscordUserId> = Vec::new();
-            for (discord_user_id, _) in &guild_config.users {
+            for (discord_user_id, user_config) in &guild_config.users {
                 let user_alerts = model::discord_user_report_times(guild_config, discord_user_id);
 
                 if guild_ignores_time(guild_id) {
-                    discord_user_ids_to_alert.push(discord_user_id.clone());
+                    users_to_alert.push(UserAlertInfo {
+                        discord_user_id: discord_user_id.clone(),
+                        github_names: user_config.github_names.clone(),
+                    });
                     discord_user_ids_to_weekly_alert.push(discord_user_id.clone());
                 } else {
                     // Look for any alert times that we have passed since the last report attempt.
                     let should_report =
                         |report_time| last_report_timestamp < report_time && now >= report_time;
                     if user_alerts.iter().any(should_report) {
-                        discord_user_ids_to_alert.push(discord_user_id.clone());
+                        users_to_alert.push(UserAlertInfo {
+                            discord_user_id: discord_user_id.clone(),
+                            github_names: user_config.github_names.clone(),
+                        });
 
                         if model::discord_user_weekly_report_needed(guild_config, discord_user_id) {
                             discord_user_ids_to_weekly_alert.push(discord_user_id.clone());
@@ -151,7 +161,7 @@ async fn report_alerts(
             }
 
             if let Some(filter_user) = &filter_to_discord_user {
-                discord_user_ids_to_alert.retain_mut(|user| *user == *filter_user);
+                users_to_alert.retain(|u| u.discord_user_id == *filter_user);
                 discord_user_ids_to_weekly_alert.retain_mut(|user| *user == *filter_user);
             }
 
@@ -163,7 +173,7 @@ async fn report_alerts(
 
             alerts.push(GuildAlerts {
                 discord_channel_id: guild_config.report_channel_id.clone(),
-                discord_user_ids: discord_user_ids_to_alert,
+                users: users_to_alert,
                 prs,
                 issues: issues.clone(),
             });
@@ -205,13 +215,14 @@ async fn report_alerts(
     discord::util::save_config(&data).await?;
 
     for alert in alerts {
-        for discord_user_id in alert.discord_user_ids {
+        for user_info in alert.users {
             report_alerts_for_user(
                 http.clone(),
                 alert.prs.clone(),
                 alert.issues.clone(),
                 alert.discord_channel_id.clone(),
-                discord_user_id,
+                user_info.discord_user_id,
+                &user_info.github_names,
             )
             .await?;
         }
@@ -315,12 +326,15 @@ async fn report_alerts_for_user(
     issues: Arc<Vec<github::LeadsIssue>>,
     discord_channel_id: model::DiscordChannelId,
     discord_user_id: model::DiscordUserId,
+    github_names: &[model::GithubUserName],
 ) -> Result<(), DiscordError> {
     const PR_HEADER: &str = ":notepad_spiral: PRs for review ";
     const BLOCKING_ISSUES_HEADER: &str = ":fire_engine: Open leads issues (blocking) ";
+    const MY_PRS_HEADER: &str = ":arrow_right: PRs to update ";
 
     let pr_header = format!("{}{}", PR_HEADER, discord_user_id);
     let issue_header = format!("{}{}", BLOCKING_ISSUES_HEADER, discord_user_id);
+    let my_prs_header = format!("{}{}", MY_PRS_HEADER, discord_user_id);
 
     delete_messages_with_prefix(http.clone(), discord_channel_id.clone(), pr_header.clone())
         .await?;
@@ -328,6 +342,12 @@ async fn report_alerts_for_user(
         http.clone(),
         discord_channel_id.clone(),
         issue_header.clone(),
+    )
+    .await?;
+    delete_messages_with_prefix(
+        http.clone(),
+        discord_channel_id.clone(),
+        my_prs_header.clone(),
     )
     .await?;
 
@@ -345,6 +365,21 @@ async fn report_alerts_for_user(
             issue.urgency == github::Urgency::Blocked && issue.leads.contains(&discord_user_id)
         })
         .collect();
+    let my_prs: Vec<_> = prs
+        .iter()
+        .filter(|pr| {
+            let is_author = pr.github_pr.user.as_ref().map_or(false, |u| {
+                let github_name: model::GithubUserName = u.as_ref().into();
+                github_names.contains(&github_name)
+            });
+
+            let no_reviewers = pr.reviewers.is_empty();
+            let no_teams = pr.github_pr.requested_teams.as_ref().map_or(true, |t| t.is_empty());
+            let not_draft = !pr.github_pr.draft.unwrap_or(false);
+
+            is_author && no_reviewers && no_teams && not_draft
+        })
+        .collect();
 
     generate_alert_messages(
         http.clone(),
@@ -355,10 +390,18 @@ async fn report_alerts_for_user(
     )
     .await?;
     generate_alert_messages(
-        http,
+        http.clone(),
         issue_header,
         user_issues,
         format_issue,
+        discord_channel_id.clone(),
+    )
+    .await?;
+    generate_alert_messages(
+        http,
+        my_prs_header,
+        my_prs,
+        format_pr,
         discord_channel_id,
     )
     .await?;

--- a/src/discord/tasks/watch_github.rs
+++ b/src/discord/tasks/watch_github.rs
@@ -317,11 +317,11 @@ async fn report_alerts_for_user(
     discord_user_id: model::DiscordUserId,
 ) -> Result<(), DiscordError> {
     const REVIEW_PRS_HEADER: &str = ":notepad_spiral: PRs for review ";
-    const REVIEW_ISSUES_HEADER: &str = ":fire_engine: Open leads issues (blocking) ";
+    const LEADS_ISSUES_HEADER: &str = ":fire_engine: Open leads issues (blocking) ";
     const AUTHOR_PRS_HEADER: &str = ":arrow_right: PRs to update ";
 
     let review_prs_header = format!("{}{}", REVIEW_PRS_HEADER, discord_user_id);
-    let review_issues_header = format!("{}{}", REVIEW_ISSUES_HEADER, discord_user_id);
+    let leads_issues_header = format!("{}{}", LEADS_ISSUES_HEADER, discord_user_id);
     let author_prs_header = format!("{}{}", AUTHOR_PRS_HEADER, discord_user_id);
 
     delete_messages_with_prefix(http.clone(), discord_channel_id.clone(), review_prs_header.clone())
@@ -329,7 +329,7 @@ async fn report_alerts_for_user(
     delete_messages_with_prefix(
         http.clone(),
         discord_channel_id.clone(),
-        review_issues_header.clone(),
+        leads_issues_header.clone(),
     )
     .await?;
     delete_messages_with_prefix(
@@ -347,7 +347,7 @@ async fn report_alerts_for_user(
                 .any(|r| r.discord_users.contains(&discord_user_id))
         })
         .collect();
-    let review_issues: Vec<_> = issues
+    let leads_issues: Vec<_> = issues
         .iter()
         .filter(|issue: &_| {
             issue.urgency == github::Urgency::Blocked && issue.leads.contains(&discord_user_id)
@@ -378,8 +378,8 @@ async fn report_alerts_for_user(
     .await?;
     generate_alert_messages(
         http.clone(),
-        review_issues_header,
-        review_issues,
+        leads_issues_header,
+        leads_issues,
         format_issue,
         discord_channel_id.clone(),
     )

--- a/src/discord/tasks/watch_github.rs
+++ b/src/discord/tasks/watch_github.rs
@@ -316,26 +316,26 @@ async fn report_alerts_for_user(
     discord_channel_id: model::DiscordChannelId,
     discord_user_id: model::DiscordUserId,
 ) -> Result<(), DiscordError> {
-    const PR_HEADER: &str = ":notepad_spiral: PRs for review ";
-    const BLOCKING_ISSUES_HEADER: &str = ":fire_engine: Open leads issues (blocking) ";
-    const MY_PRS_HEADER: &str = ":arrow_right: PRs to update ";
+    const REVIEW_PRS_HEADER: &str = ":notepad_spiral: PRs for review ";
+    const REVIEW_ISSUES_HEADER: &str = ":fire_engine: Open leads issues (blocking) ";
+    const AUTHOR_PRS_HEADER: &str = ":arrow_right: PRs to update ";
 
-    let pr_header = format!("{}{}", PR_HEADER, discord_user_id);
-    let issue_header = format!("{}{}", BLOCKING_ISSUES_HEADER, discord_user_id);
-    let my_prs_header = format!("{}{}", MY_PRS_HEADER, discord_user_id);
+    let review_prs_header = format!("{}{}", REVIEW_PRS_HEADER, discord_user_id);
+    let review_issues_header = format!("{}{}", REVIEW_ISSUES_HEADER, discord_user_id);
+    let author_prs_header = format!("{}{}", AUTHOR_PRS_HEADER, discord_user_id);
 
-    delete_messages_with_prefix(http.clone(), discord_channel_id.clone(), pr_header.clone())
+    delete_messages_with_prefix(http.clone(), discord_channel_id.clone(), review_prs_header.clone())
         .await?;
     delete_messages_with_prefix(
         http.clone(),
         discord_channel_id.clone(),
-        issue_header.clone(),
+        review_issues_header.clone(),
     )
     .await?;
     delete_messages_with_prefix(
         http.clone(),
         discord_channel_id.clone(),
-        my_prs_header.clone(),
+        author_prs_header.clone(),
     )
     .await?;
 
@@ -370,7 +370,7 @@ async fn report_alerts_for_user(
 
     generate_alert_messages(
         http.clone(),
-        pr_header,
+        review_prs_header,
         review_prs,
         format_pr,
         discord_channel_id.clone(),
@@ -378,7 +378,7 @@ async fn report_alerts_for_user(
     .await?;
     generate_alert_messages(
         http.clone(),
-        issue_header,
+        review_issues_header,
         review_issues,
         format_issue,
         discord_channel_id.clone(),
@@ -386,7 +386,7 @@ async fn report_alerts_for_user(
     .await?;
     generate_alert_messages(
         http,
-        my_prs_header,
+        author_prs_header,
         author_prs,
         format_pr,
         discord_channel_id,

--- a/src/github/prs.rs
+++ b/src/github/prs.rs
@@ -20,6 +20,12 @@ fn github_pr_url(cfg: &model::GuildConfig, number: u64) -> String {
 }
 
 #[allow(dead_code)]
+pub struct Author {
+    pub github_user: model::GithubUserName,
+    pub discord_users: Vec<model::DiscordUserId>,
+}
+
+#[allow(dead_code)]
 pub struct Reviewer {
     pub github_user: model::GithubUserName,
     pub discord_users: Vec<model::DiscordUserId>,
@@ -28,6 +34,7 @@ pub struct Reviewer {
 pub struct Pr {
     pub github_pr: PullRequest,
     pub url: String,
+    pub author: Option<Author>,
     pub reviewers: Vec<Reviewer>,
 }
 
@@ -78,9 +85,24 @@ pub fn filter_prs_for_guild<'a>(
             }
         }
 
+        let author = pr.user.as_ref().map(|u| {
+            let github_user: model::GithubUserName = u.as_ref().into();
+            let mut discord_users = Vec::new();
+            for (discord_user_id, user_config) in &cfg.users {
+                if user_config.github_names.contains(&github_user) {
+                    discord_users.push(discord_user_id.clone());
+                }
+            }
+            Author {
+                github_user,
+                discord_users,
+            }
+        });
+
         Pr {
             url: github_pr_url(cfg, pr.number),
             github_pr: pr,
+            author,
             reviewers,
         }
     })


### PR DESCRIPTION
This PR updates the bot to include in each person's list of pings a list of open PRs they authored where it's their turn next.

Assisted-by: Gemini via Antigravity